### PR TITLE
Fix typo in icon name

### DIFF
--- a/glyphmaps/AntDesign.json
+++ b/glyphmaps/AntDesign.json
@@ -2,7 +2,7 @@
   "stepforward": 58880,
   "stepbackward": 58881,
   "forward": 58882,
-  "banckward": 58883,
+  "backward": 58883,
   "caretright": 58884,
   "caretleft": 58885,
   "caretdown": 58886,


### PR DESCRIPTION
Reported here:
https://forums.expo.io/t/typo-in-expo-vector-icons-directory/33700?u=wodin